### PR TITLE
Trailing subject token delimiter issue

### DIFF
--- a/src/Proxy/NatsSubjectParser.cs
+++ b/src/Proxy/NatsSubjectParser.cs
@@ -7,7 +7,7 @@ namespace Proxy
         internal static string Parse(string httpMethod, string urlPath)
         {
             // replace all forward slashes with periods in the http request path
-            var subjectPath = urlPath.Replace('/', '.');
+            var subjectPath = urlPath.Replace('/', '.').Trim('.');
 
             // the subject is the http method followed by the path all lowercased
             var subject = string.Concat(httpMethod, subjectPath).ToLower();

--- a/src/Proxy/NatsSubjectParser.cs
+++ b/src/Proxy/NatsSubjectParser.cs
@@ -7,7 +7,7 @@ namespace Proxy
         internal static string Parse(string httpMethod, string urlPath)
         {
             // replace all forward slashes with periods in the http request path
-            var subjectPath = urlPath.Replace('/', '.').Trim('.');
+            var subjectPath = urlPath.Replace('/', '.').TrimEnd('.');
 
             // the subject is the http method followed by the path all lowercased
             var subject = string.Concat(httpMethod, subjectPath).ToLower();


### PR DESCRIPTION
"GET /api/resource/" was being turned into "get.api.resource." and not matching any defined routes.