### PR TITLE
Fix parsing of extended properties during pipeline execution

### DIFF
--- a/src/Proxy/PipelineExecutor.cs
+++ b/src/Proxy/PipelineExecutor.cs
@@ -73,7 +73,7 @@ namespace Proxy
             message.ErrorMessage = responseMessage.ErrorMessage ?? message.ErrorMessage;
 
             // we want to concatenate the extended properties as each step in the pipeline may be adding information
-            message.ExtendedProperties.ToList().ForEach(h =>
+            responseMessage.ExtendedProperties.ToList().ForEach(h =>
             {
                 if (!message.ExtendedProperties.ContainsKey(h.Key))
                 {


### PR DESCRIPTION
While testing the pipeline functionality I noticed that the `extendedProperties` weren't propagating properly. This seems to be caused by a reference to the wrong message object in the `MergeMessageProperties` method of the `PipelineExecutor` class. This PR changes the reference to the `responseMessage`, in the same vain as `RequestHeaders` and `ResponseHeaders` are handled.